### PR TITLE
Enable automatic bumping of patch dependencies.

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -22,6 +22,11 @@ api = "0.6"
     uri = "https://files.pythonhosted.org/packages/97/75/e1d93257956f5be859b2f4ab0d9b8ee881fbb866d19010aa64dc9ff2b156/poetry-1.1.6.tar.gz"
     version = "1.1.6"
 
+  [[metadata.dependency-constraints]]
+    constraint = "1.1.*"
+    id = "poetry"
+    patches = 2
+
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
 


### PR DESCRIPTION
## Summary
Enables auto-updating of patch dependencies for `poetry` via `jam update-dependencies`.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
