### PR TITLE
tests: make test assertion a bit more extensible

### DIFF
--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -87,7 +87,6 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(fmt.Sprintf(`    PYTHONPATH -> "\/layers\/%s\/poetry\/lib\/python\d+\.\d+\/site-packages:\$PYTHONPATH"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))),
 			))
 			Expect(logs).To(ContainLines(
-				MatchRegexp(`\s*CPython Buildpack v?\d+\.\d+\.\d+`),
 				"  Resolving CPython version",
 				"    Candidate version sources (in priority order):",
 				`      pyproject.toml -> "3.8.*"`,

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -87,7 +87,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(fmt.Sprintf(`    PYTHONPATH -> "\/layers\/%s\/poetry\/lib\/python\d+\.\d+\/site-packages:\$PYTHONPATH"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))),
 			))
 			Expect(logs).To(ContainLines(
-				MatchRegexp(`Paketo CPython Buildpack \d+\.\d+\.\d+`),
+				MatchRegexp(`\s*CPython Buildpack v?\d+\.\d+\.\d+`),
 				"  Resolving CPython version",
 				"    Candidate version sources (in priority order):",
 				`      pyproject.toml -> "3.8.*"`,


### PR DESCRIPTION
Poetry buildpack works not only with Paketo CPython buildpack as
dependency, but with any other CPython buildpack that observes the
CPython buildpack's API

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
