### PR TITLE
Use packit.Fail to indicate when this buildpack will not Detect

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -11,4 +11,3 @@ const (
 var Priorities = []interface{}{
 	"BP_PIP_VERSION",
 }
-

--- a/detect_test.go
+++ b/detect_test.go
@@ -2,15 +2,16 @@ package poetry_test
 
 import (
 	"errors"
-	"github.com/paketo-buildpacks/poetry/fakes"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
-	packit "github.com/paketo-buildpacks/packit/v2"
-	"github.com/paketo-buildpacks/poetry"
-	"github.com/sclevine/spec"
-
 	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/poetry"
+	"github.com/paketo-buildpacks/poetry/fakes"
+	"github.com/sclevine/spec"
 )
 
 func testDetect(t *testing.T, context spec.G, it spec.S) {
@@ -19,64 +20,37 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		parsePythonVersion *fakes.PyProjectPythonVersionParser
 
+		workingDir string
+
 		detect packit.DetectFunc
 	)
 
 	it.Before(func() {
 		parsePythonVersion = &fakes.PyProjectPythonVersionParser{}
 
+		var err error
+		workingDir, err = ioutil.TempDir("", "working-dir")
+		Expect(err).NotTo(HaveOccurred())
+
 		detect = poetry.Detect(parsePythonVersion)
 	})
 
-	it("returns a plan that provides poetry", func() {
-		parsePythonVersion.ParsePythonVersionCall.Returns.String = "1.2.3"
-
-		result, err := detect(packit.DetectContext{
-			WorkingDir: "/working-dir",
-		})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(packit.DetectResult{
-			Plan: packit.BuildPlan{
-				Provides: []packit.BuildPlanProvision{
-					{Name: "poetry"},
-				},
-				Requires: []packit.BuildPlanRequirement{
-					{
-						Name: poetry.Pip,
-						Metadata: poetry.BuildPlanMetadata{
-							Build: true,
-						},
-					},
-					{
-						Name: poetry.CPython,
-						Metadata: poetry.BuildPlanMetadata{
-							Build:         true,
-							Version:       "1.2.3",
-							VersionSource: "pyproject.toml",
-						},
-					},
-				},
-			},
-		}))
+	it.After(func() {
+		Expect(os.RemoveAll(workingDir)).To(Succeed())
 	})
 
-	context("when the BP_POETRY_VERSION is set", func() {
+	context("when pyproject.toml is present", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BP_POETRY_VERSION", "some-version")).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "pyproject.toml"), []byte(""), 0755)).To(Succeed())
 		})
 
-		it.After(func() {
-			Expect(os.Unsetenv("BP_POETRY_VERSION")).To(Succeed())
-		})
-
-		it("returns a plan that requires that version of poetry", func() {
-			parsePythonVersion.ParsePythonVersionCall.Returns.String = "9.8.7"
+		it("returns a plan that provides poetry", func() {
+			parsePythonVersion.ParsePythonVersionCall.Returns.String = "1.2.3"
 
 			result, err := detect(packit.DetectContext{
-				WorkingDir: "/other-dir",
+				WorkingDir: workingDir,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(parsePythonVersion.ParsePythonVersionCall.Receives.Path).To(Equal("/other-dir"))
 			Expect(result).To(Equal(packit.DetectResult{
 				Plan: packit.BuildPlan{
 					Provides: []packit.BuildPlanProvision{
@@ -93,33 +67,95 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: poetry.CPython,
 							Metadata: poetry.BuildPlanMetadata{
 								Build:         true,
-								Version:       "9.8.7",
+								Version:       "1.2.3",
 								VersionSource: "pyproject.toml",
-							},
-						},
-						{
-							Name: "poetry",
-							Metadata: poetry.BuildPlanMetadata{
-								VersionSource: "BP_POETRY_VERSION",
-								Version:       "some-version",
 							},
 						},
 					},
 				},
 			}))
 		})
-	}, spec.Sequential())
 
-	context("error handling", func() {
-		it("handles an error from the pyproject.toml parser", func() {
-			expectedErr := errors.New("hi")
-			parsePythonVersion.ParsePythonVersionCall.Returns.Error = expectedErr
-
-			result, err := detect(packit.DetectContext{
-				WorkingDir: "/working-dir",
+		context("when the BP_POETRY_VERSION is set", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BP_POETRY_VERSION", "some-version")).To(Succeed())
 			})
-			Expect(result).To(Equal(packit.DetectResult{}))
-			Expect(err).To(Equal(expectedErr))
+
+			it.After(func() {
+				Expect(os.Unsetenv("BP_POETRY_VERSION")).To(Succeed())
+			})
+
+			it("returns a plan that requires that version of poetry", func() {
+				parsePythonVersion.ParsePythonVersionCall.Returns.String = "9.8.7"
+
+				result, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(parsePythonVersion.ParsePythonVersionCall.Receives.String).To(Equal(filepath.Join(workingDir, "pyproject.toml")))
+				Expect(result).To(Equal(packit.DetectResult{
+					Plan: packit.BuildPlan{
+						Provides: []packit.BuildPlanProvision{
+							{Name: "poetry"},
+						},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: poetry.Pip,
+								Metadata: poetry.BuildPlanMetadata{
+									Build: true,
+								},
+							},
+							{
+								Name: poetry.CPython,
+								Metadata: poetry.BuildPlanMetadata{
+									Build:         true,
+									Version:       "9.8.7",
+									VersionSource: "pyproject.toml",
+								},
+							},
+							{
+								Name: "poetry",
+								Metadata: poetry.BuildPlanMetadata{
+									VersionSource: "BP_POETRY_VERSION",
+									Version:       "some-version",
+								},
+							},
+						},
+					},
+				}))
+			})
+		})
+
+		context("error handling", func() {
+			// the python dependency is mandatory
+			// https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies
+			it("fails detection when no python version found", func() {
+				parsePythonVersion.ParsePythonVersionCall.Returns.String = ""
+
+				_, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).To(MatchError(packit.Fail.WithMessage("pyproject.toml must include [tool.poetry.dependencies.python], see https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies")))
+			})
+
+			it("handles an error from the pyproject.toml parser", func() {
+				expectedErr := errors.New("hi")
+				parsePythonVersion.ParsePythonVersionCall.Returns.Error = expectedErr
+
+				_, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).To(Equal(expectedErr))
+			})
+		})
+	})
+
+	context("when pyproject.toml is not present", func() {
+		it("fails detection", func() {
+			_, err := detect(packit.DetectContext{
+				WorkingDir: workingDir,
+			})
+			Expect(err).To(MatchError("pyproject.toml is not present"))
 		})
 	})
 }

--- a/fakes/pyproject_parser.go
+++ b/fakes/pyproject_parser.go
@@ -7,7 +7,7 @@ type PyProjectPythonVersionParser struct {
 		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
-			Path string
+			String string
 		}
 		Returns struct {
 			String string
@@ -21,7 +21,7 @@ func (f *PyProjectPythonVersionParser) ParsePythonVersion(param1 string) (string
 	f.ParsePythonVersionCall.mutex.Lock()
 	defer f.ParsePythonVersionCall.mutex.Unlock()
 	f.ParsePythonVersionCall.CallCount++
-	f.ParsePythonVersionCall.Receives.Path = param1
+	f.ParsePythonVersionCall.Receives.String = param1
 	if f.ParsePythonVersionCall.Stub != nil {
 		return f.ParsePythonVersionCall.Stub(param1)
 	}

--- a/init_test.go
+++ b/init_test.go
@@ -10,7 +10,7 @@ import (
 func TestUnit(t *testing.T) {
 	suite := spec.New("poetry", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("Build", testBuild)
-	suite("Detect", testDetect)
+	suite("Detect", testDetect, spec.Sequential())
 	suite("InstallProcess", testPoetryInstallProcess)
 	suite("SiteProcess", testSiteProcess)
 	suite("PyProjectParse", testPyProjectParser)

--- a/pyproject_parser.go
+++ b/pyproject_parser.go
@@ -1,9 +1,7 @@
 package poetry
 
 import (
-	"errors"
 	"github.com/BurntSushi/toml"
-	"path/filepath"
 )
 
 type PyProjectToml struct {
@@ -16,8 +14,6 @@ type PyProjectToml struct {
 	}
 }
 
-const PyProjectTomlFile = "pyproject.toml"
-
 type PyProjectParser struct {
 }
 
@@ -25,12 +21,13 @@ func NewPyProjectParser() PyProjectParser {
 	return PyProjectParser{}
 }
 
-func (p PyProjectParser) ParsePythonVersion(path string) (version string, err error) {
+func (p PyProjectParser) ParsePythonVersion(pyProjectToml string) (string, error) {
 	var pyProject PyProjectToml
-	_, err = toml.DecodeFile(filepath.Join(path, PyProjectTomlFile), &pyProject)
 
-	if pyProject.Tool.Poetry.Dependencies.Python == "" {
-		return "", errors.New("pyproject.toml must include [tool.poetry.dependencies.python], see https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies")
+	_, err := toml.DecodeFile(pyProjectToml, &pyProject)
+	if err != nil {
+		return "", err
 	}
-	return pyProject.Tool.Poetry.Dependencies.Python, err
+
+	return pyProject.Tool.Poetry.Dependencies.Python, nil
 }


### PR DESCRIPTION
## Summary
Resolves #27 

## Use Cases
Don't log messages when this buildpack can't find `pyproject.toml`. This is a perfectly normal scenario.

If there is a `pyproject.toml` without `tool.poetry.dependencies.python` then that's a user error and should be logged.

### Scenario: without `pyproject.toml`

```shell
===> DETECTING
[detector] ERROR: No buildpack groups passed detection.
[detector] ERROR: Please check that you are running against the correct path.
[detector] ERROR: failed to detect: no buildpacks participating
```

### Scenario: with `pyproject.toml` and without `tool.poetry.dependencies.python`:
```shell
===> DETECTING
[detector] ======== Output: paketo-buildpacks/poetry@1.0.1 ========
[detector] pyproject.toml must include [tool.poetry.dependencies.python], see https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies
[detector] err:  paketo-buildpacks/poetry@1.0.1 (1)
[detector] ERROR: No buildpack groups passed detection.
[detector] ERROR: failed to detect: buildpack(s) failed with err
```

### Scenario: with `pyproject.toml` and with `tool.poetry.dependencies.python`:
Using `pack -v`:

```shell
===> DETECTING
...
[detector] ======== Results ========
[detector] pass: paketo-buildpacks/poetry@1.0.1
[detector] Resolving plan... (try #1)
[detector] fail: paketo-buildpacks/poetry@1.0.1 requires pip
[detector] ERROR: No buildpack groups passed detection.
[detector] ERROR: Please check that you are running against the correct path.
[detector] ERROR: failed to detect: no buildpacks participating
```

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
