### PR TITLE
Replace references to deprecated ioutil package

### DIFF
--- a/build.go
+++ b/build.go
@@ -2,7 +2,7 @@ package poetry
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -105,7 +105,7 @@ func Build(entryResolver EntryResolver, dependencyManager DependencyManager, ins
 			// Install the poetry source to a temporary dir, since we only need access to
 			// it as an intermediate step when installing poetry.
 			// It doesn't need to go into a layer, since we won't need it in future builds.
-			poetrySrcDir, err := ioutil.TempDir("", "poetry-source")
+			poetrySrcDir, err := os.MkdirTemp("", "poetry-source")
 			if err != nil {
 				return fmt.Errorf("failed to create temp poetry-source dir: %w", err)
 			}

--- a/detect_test.go
+++ b/detect_test.go
@@ -2,7 +2,6 @@ package poetry_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,7 +26,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
 		parsePythonVersion = &fakes.PyProjectPythonVersionParser{}

--- a/detect_test.go
+++ b/detect_test.go
@@ -26,11 +26,14 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		parsePythonVersion = &fakes.PyProjectPythonVersionParser{}
-
 		var err error
 		workingDir, err = ioutil.TempDir("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
+
+		parsePythonVersion = &fakes.PyProjectPythonVersionParser{}
+		parsePythonVersion.ParsePythonVersionCall.Returns.String = "1.2.3"
+
+		Expect(os.WriteFile(filepath.Join(workingDir, "pyproject.toml"), []byte(""), 0755)).To(Succeed())
 
 		detect = poetry.Detect(parsePythonVersion)
 	})
@@ -39,18 +42,52 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(workingDir)).To(Succeed())
 	})
 
-	context("when pyproject.toml is present", func() {
+	it("returns a plan that provides poetry", func() {
+		result, err := detect(packit.DetectContext{
+			WorkingDir: workingDir,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(result).To(Equal(packit.DetectResult{
+			Plan: packit.BuildPlan{
+				Provides: []packit.BuildPlanProvision{
+					{Name: "poetry"},
+				},
+				Requires: []packit.BuildPlanRequirement{
+					{
+						Name: poetry.Pip,
+						Metadata: poetry.BuildPlanMetadata{
+							Build: true,
+						},
+					},
+					{
+						Name: poetry.CPython,
+						Metadata: poetry.BuildPlanMetadata{
+							Build:         true,
+							Version:       "1.2.3",
+							VersionSource: "pyproject.toml",
+						},
+					},
+				},
+			},
+		}))
+	})
+
+	context("when the BP_POETRY_VERSION is set", func() {
 		it.Before(func() {
-			Expect(os.WriteFile(filepath.Join(workingDir, "pyproject.toml"), []byte(""), 0755)).To(Succeed())
+			Expect(os.Setenv("BP_POETRY_VERSION", "some-version")).To(Succeed())
 		})
 
-		it("returns a plan that provides poetry", func() {
-			parsePythonVersion.ParsePythonVersionCall.Returns.String = "1.2.3"
+		it.After(func() {
+			Expect(os.Unsetenv("BP_POETRY_VERSION")).To(Succeed())
+		})
 
+		it("returns a plan that requires that version of poetry", func() {
 			result, err := detect(packit.DetectContext{
 				WorkingDir: workingDir,
 			})
 			Expect(err).NotTo(HaveOccurred())
+			Expect(parsePythonVersion.ParsePythonVersionCall.Receives.String).To(Equal(filepath.Join(workingDir, "pyproject.toml")))
 			Expect(result).To(Equal(packit.DetectResult{
 				Plan: packit.BuildPlan{
 					Provides: []packit.BuildPlanProvision{
@@ -71,91 +108,74 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 								VersionSource: "pyproject.toml",
 							},
 						},
+						{
+							Name: "poetry",
+							Metadata: poetry.BuildPlanMetadata{
+								VersionSource: "BP_POETRY_VERSION",
+								Version:       "some-version",
+							},
+						},
 					},
 				},
 			}))
 		})
 
-		context("when the BP_POETRY_VERSION is set", func() {
+		context("when pyproject.toml is not present", func() {
 			it.Before(func() {
-				Expect(os.Setenv("BP_POETRY_VERSION", "some-version")).To(Succeed())
+				Expect(os.RemoveAll(filepath.Join(workingDir, "pyproject.toml"))).To(Succeed())
 			})
 
-			it.After(func() {
-				Expect(os.Unsetenv("BP_POETRY_VERSION")).To(Succeed())
-			})
-
-			it("returns a plan that requires that version of poetry", func() {
-				parsePythonVersion.ParsePythonVersionCall.Returns.String = "9.8.7"
-
-				result, err := detect(packit.DetectContext{
+			it("fails detection", func() {
+				_, err := detect(packit.DetectContext{
 					WorkingDir: workingDir,
 				})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(parsePythonVersion.ParsePythonVersionCall.Receives.String).To(Equal(filepath.Join(workingDir, "pyproject.toml")))
-				Expect(result).To(Equal(packit.DetectResult{
-					Plan: packit.BuildPlan{
-						Provides: []packit.BuildPlanProvision{
-							{Name: "poetry"},
-						},
-						Requires: []packit.BuildPlanRequirement{
-							{
-								Name: poetry.Pip,
-								Metadata: poetry.BuildPlanMetadata{
-									Build: true,
-								},
-							},
-							{
-								Name: poetry.CPython,
-								Metadata: poetry.BuildPlanMetadata{
-									Build:         true,
-									Version:       "9.8.7",
-									VersionSource: "pyproject.toml",
-								},
-							},
-							{
-								Name: "poetry",
-								Metadata: poetry.BuildPlanMetadata{
-									VersionSource: "BP_POETRY_VERSION",
-									Version:       "some-version",
-								},
-							},
-						},
-					},
-				}))
+				Expect(err).To(MatchError(packit.Fail.WithMessage("pyproject.toml is not present")))
 			})
 		})
 
-		context("error handling", func() {
-			// the python dependency is mandatory
-			// https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies
-			it("fails detection when no python version found", func() {
+		context("when no python version is returned from the parser", func() {
+			it.Before(func() {
 				parsePythonVersion.ParsePythonVersionCall.Returns.String = ""
+			})
 
+			it("fails detection", func() {
 				_, err := detect(packit.DetectContext{
 					WorkingDir: workingDir,
 				})
 				Expect(err).To(MatchError(packit.Fail.WithMessage("pyproject.toml must include [tool.poetry.dependencies.python], see https://python-poetry.org/docs/pyproject/#dependencies-and-dev-dependencies")))
 			})
-
-			it("handles an error from the pyproject.toml parser", func() {
-				expectedErr := errors.New("hi")
-				parsePythonVersion.ParsePythonVersionCall.Returns.Error = expectedErr
-
-				_, err := detect(packit.DetectContext{
-					WorkingDir: workingDir,
-				})
-				Expect(err).To(Equal(expectedErr))
-			})
 		})
-	})
 
-	context("when pyproject.toml is not present", func() {
-		it("fails detection", func() {
-			_, err := detect(packit.DetectContext{
-				WorkingDir: workingDir,
+		context("error handling", func() {
+			context("when there is an error determining if the pyproject.toml file exists", func() {
+				it.Before(func() {
+					Expect(os.Chmod(workingDir, 0000)).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Chmod(workingDir, os.ModePerm)).To(Succeed())
+				})
+
+				it("returns the error", func() {
+					_, err := detect(packit.DetectContext{
+						WorkingDir: workingDir,
+					})
+					Expect(err).To(MatchError(ContainSubstring("permission denied")))
+				})
 			})
-			Expect(err).To(MatchError("pyproject.toml is not present"))
+
+			context("when the pyproject parser returns an error", func() {
+				it.Before(func() {
+					parsePythonVersion.ParsePythonVersionCall.Returns.Error = errors.New("some-error")
+				})
+
+				it("returns the error", func() {
+					_, err := detect(packit.DetectContext{
+						WorkingDir: workingDir,
+					})
+					Expect(err).To(Equal(errors.New("some-error")))
+				})
+			})
 		})
 	})
 }

--- a/pyproject_parser_test.go
+++ b/pyproject_parser_test.go
@@ -1,7 +1,6 @@
 package poetry_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ python = "===1.2.3"`
 
 	it.Before(func() {
 		var err error
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
 		pyProjectToml = filepath.Join(workingDir, poetry.PyProjectTomlFile)
@@ -42,9 +41,7 @@ python = "===1.2.3"`
 
 	context("Calling ParsePythonVersion", func() {
 		it("parses version", func() {
-			Expect(ioutil.WriteFile(
-				pyProjectToml,
-				[]byte(version), 0644)).To(Succeed())
+			Expect(os.WriteFile(pyProjectToml, []byte(version), 0644)).To(Succeed())
 
 			version, err := parser.ParsePythonVersion(pyProjectToml)
 			Expect(err).NotTo(HaveOccurred())
@@ -52,9 +49,7 @@ python = "===1.2.3"`
 		})
 
 		it("returns empty string if file does not contain 'tool.poetry.dependencies.python'", func() {
-			Expect(ioutil.WriteFile(
-				pyProjectToml,
-				[]byte(""), 0644)).To(Succeed())
+			Expect(os.WriteFile(pyProjectToml, []byte(""), 0644)).To(Succeed())
 
 			version, err := parser.ParsePythonVersion(pyProjectToml)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This PR removes all references to the deprecated `ioutil` package and replaces them with their official replacements. See https://pkg.go.dev/io/ioutil for details on these replacements.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
