### PR TITLE
Removes built_at

### DIFF
--- a/build.go
+++ b/build.go
@@ -180,7 +180,6 @@ func Build(
 
 		poetryLayer.Metadata = map[string]interface{}{
 			DependencySHAKey: dependency.SHA256,
-			"built_at":       clock.Now().Format(time.RFC3339Nano),
 		}
 
 		return packit.BuildResult{

--- a/build_test.go
+++ b/build_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	packit "github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/chronos"
@@ -29,7 +28,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		layersDir string
 		cnbDir    string
-		timestamp time.Time
 
 		entryResolver     *fakes.EntryResolver
 		dependencyManager *fakes.DependencyManager
@@ -50,11 +48,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		cnbDir, err = os.MkdirTemp("", "cnb")
 		Expect(err).NotTo(HaveOccurred())
-
-		timestamp = time.Now()
-		clock := chronos.NewClock(func() time.Time {
-			return timestamp
-		})
 
 		entryResolver = &fakes.EntryResolver{}
 		entryResolver.ResolveCall.Returns.BuildpackPlanEntry = packit.BuildpackPlanEntry{
@@ -103,7 +96,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			installProcess,
 			siteProcess,
 			sbomGenerator,
-			clock,
+			chronos.DefaultClock,
 			logEmitter,
 		)
 
@@ -152,9 +145,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(layer.Launch).To(BeFalse())
 		Expect(layer.Cache).To(BeFalse())
 
-		Expect(layer.Metadata).To(HaveLen(2))
+		Expect(layer.Metadata).To(HaveLen(1))
 		Expect(layer.Metadata["dependency-sha"]).To(Equal("poetry-dependency-sha"))
-		Expect(layer.Metadata["built_at"]).To(Equal(timestamp.Format(time.RFC3339Nano)))
 
 		Expect(layer.SBOM.Formats()).To(Equal([]packit.SBOMFormat{
 			{

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -115,5 +115,6 @@ func TestIntegration(t *testing.T) {
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}))
 	suite("Default", testDefault, spec.Parallel())
+	suite("LayerReuse", testLayerReuse, spec.Parallel())
 	suite.Run(t)
 }

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -1,0 +1,126 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		docker occam.Docker
+		pack   occam.Pack
+
+		imageIDs     map[string]struct{}
+		containerIDs map[string]struct{}
+	)
+
+	it.Before(func() {
+		docker = occam.NewDocker()
+		pack = occam.NewPack()
+		imageIDs = map[string]struct{}{}
+		containerIDs = map[string]struct{}{}
+	})
+
+	it.After(func() {
+		for id := range containerIDs {
+			Expect(docker.Container.Remove.Execute(id)).To(Succeed())
+		}
+
+		for id := range imageIDs {
+			Expect(docker.Image.Remove.Execute(id)).To(Succeed())
+		}
+	})
+
+	context("when an app is rebuilt and does not change", func() {
+		var (
+			name   string
+			source string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "default_app"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		it("reuses a layer from a previous build", func() {
+			firstImage, logs, err := pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.CPython.Online,
+					settings.Buildpacks.Pip.Online,
+					settings.Buildpacks.Poetry.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), logs.String)
+
+			imageIDs[firstImage.ID] = struct{}{}
+
+			firstContainer, err := docker.Container.Run.
+				WithCommand("poetry --version").
+				Execute(firstImage.ID)
+			Expect(err).ToNot(HaveOccurred())
+
+			containerIDs[firstContainer.ID] = struct{}{}
+
+			Eventually(func() string {
+				cLogs, err := docker.Container.Logs.Execute(firstContainer.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cLogs.String()
+			}).Should(MatchRegexp(`Poetry version \d+\.\d+\.\d+`))
+
+			secondImage, logs, err := pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.CPython.Online,
+					settings.Buildpacks.Pip.Online,
+					settings.Buildpacks.Poetry.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), logs.String)
+
+			imageIDs[secondImage.ID] = struct{}{}
+
+			Expect(logs).To(ContainLines(
+				fmt.Sprintf("  Reusing cached layer /layers/%s/poetry", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+			))
+
+			secondContainer, err := docker.Container.Run.
+				WithCommand("poetry --version").
+				Execute(secondImage.ID)
+			Expect(err).ToNot(HaveOccurred())
+
+			containerIDs[secondContainer.ID] = struct{}{}
+
+			Eventually(func() string {
+				cLogs, err := docker.Container.Logs.Execute(secondContainer.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cLogs.String()
+			}).Should(MatchRegexp(`Poetry version \d+\.\d+\.\d+`))
+
+			Expect(secondImage.Buildpacks[0].Layers["poetry"].SHA).To(Equal(firstImage.Buildpacks[0].Layers["poetry"].SHA))
+		})
+	})
+}


### PR DESCRIPTION
Resolves #26

Because currently only 2 versions of the poetry dependency are supported I opted to not add a negative cache reuse test because it would be bases on the versions available to the buildpack making it brittle to the point that it would break with every version upgrade.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
