### PR TITLE
Respect BP_POETRY_VERSION when choosing version

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -174,18 +174,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(dependencyManager.ResolveCall.Receives.Version).To(Equal("default"))
 		Expect(dependencyManager.ResolveCall.Receives.Stack).To(Equal("some-stack"))
 
-		Expect(dependencyManager.DeliverCall.Receives.Dependency).To(Equal(postal.Dependency{
-			ID:      "poetry",
-			Name:    "poetry-dependency-name",
-			SHA256:  "poetry-dependency-sha",
-			Stacks:  []string{"some-stack"},
-			URI:     "poetry-dependency-uri",
-			Version: "poetry-dependency-version",
-		}))
-		Expect(dependencyManager.DeliverCall.Receives.CnbPath).To(Equal(cnbDir))
-		Expect(dependencyManager.DeliverCall.Receives.DestinationPath).To(ContainSubstring("poetry-source"))
-		Expect(dependencyManager.DeliverCall.Receives.PlatformPath).To(Equal("platform"))
-
 		Expect(dependencyManager.GenerateBillOfMaterialsCall.CallCount).To(Equal(1))
 		Expect(dependencyManager.GenerateBillOfMaterialsCall.Receives.Dependencies).To(Equal([]postal.Dependency{
 			{
@@ -200,7 +188,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(sbomGenerator.GenerateFromDependencyCall.Receives.Dir).To(Equal(filepath.Join(layersDir, "poetry")))
 
-		Expect(installProcess.ExecuteCall.Receives.SrcPath).To(Equal(dependencyManager.DeliverCall.Receives.DestinationPath))
+		Expect(installProcess.ExecuteCall.Receives.Version).To(ContainSubstring("poetry-dependency-version"))
 		Expect(installProcess.ExecuteCall.Receives.TargetLayerPath).To(Equal(filepath.Join(layersDir, "poetry")))
 
 		Expect(buffer.String()).To(ContainSubstring("Some Buildpack some-version"))
@@ -301,17 +289,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			it("returns an error", func() {
 				_, err := build(buildContext)
 				Expect(err).To(MatchError(ContainSubstring("could not remove file")))
-			})
-		})
-
-		context("when the dependency cannot be installed", func() {
-			it.Before(func() {
-				dependencyManager.DeliverCall.Returns.Error = errors.New("failed to deliver dependency")
-			})
-
-			it("returns an error", func() {
-				_, err := build(buildContext)
-				Expect(err).To(MatchError("failed to deliver dependency"))
 			})
 		})
 

--- a/fakes/dependency_manager.go
+++ b/fakes/dependency_manager.go
@@ -8,20 +8,6 @@ import (
 )
 
 type DependencyManager struct {
-	DeliverCall struct {
-		mutex     sync.Mutex
-		CallCount int
-		Receives  struct {
-			Dependency      postal.Dependency
-			CnbPath         string
-			DestinationPath string
-			PlatformPath    string
-		}
-		Returns struct {
-			Error error
-		}
-		Stub func(postal.Dependency, string, string, string) error
-	}
 	GenerateBillOfMaterialsCall struct {
 		mutex     sync.Mutex
 		CallCount int
@@ -50,19 +36,6 @@ type DependencyManager struct {
 	}
 }
 
-func (f *DependencyManager) Deliver(param1 postal.Dependency, param2 string, param3 string, param4 string) error {
-	f.DeliverCall.mutex.Lock()
-	defer f.DeliverCall.mutex.Unlock()
-	f.DeliverCall.CallCount++
-	f.DeliverCall.Receives.Dependency = param1
-	f.DeliverCall.Receives.CnbPath = param2
-	f.DeliverCall.Receives.DestinationPath = param3
-	f.DeliverCall.Receives.PlatformPath = param4
-	if f.DeliverCall.Stub != nil {
-		return f.DeliverCall.Stub(param1, param2, param3, param4)
-	}
-	return f.DeliverCall.Returns.Error
-}
 func (f *DependencyManager) GenerateBillOfMaterials(param1 ...postal.Dependency) []packit.BOMEntry {
 	f.GenerateBillOfMaterialsCall.mutex.Lock()
 	defer f.GenerateBillOfMaterialsCall.mutex.Unlock()

--- a/fakes/install_process.go
+++ b/fakes/install_process.go
@@ -7,7 +7,7 @@ type InstallProcess struct {
 		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
-			SrcPath         string
+			Version         string
 			TargetLayerPath string
 		}
 		Returns struct {
@@ -21,7 +21,7 @@ func (f *InstallProcess) Execute(param1 string, param2 string) error {
 	f.ExecuteCall.mutex.Lock()
 	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
-	f.ExecuteCall.Receives.SrcPath = param1
+	f.ExecuteCall.Receives.Version = param1
 	f.ExecuteCall.Receives.TargetLayerPath = param2
 	if f.ExecuteCall.Stub != nil {
 		return f.ExecuteCall.Stub(param1, param2)

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -111,7 +111,7 @@ func TestIntegration(t *testing.T) {
 		Execute(settings.Config.BuildPlan)
 	Expect(err).NotTo(HaveOccurred())
 
-	SetDefaultEventuallyTimeout(5 * time.Second)
+	SetDefaultEventuallyTimeout(10 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}))
 	suite("Default", testDefault, spec.Parallel())

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -116,5 +116,6 @@ func TestIntegration(t *testing.T) {
 	suite := spec.New("Integration", spec.Report(report.Terminal{}))
 	suite("Default", testDefault, spec.Parallel())
 	suite("LayerReuse", testLayerReuse, spec.Parallel())
+	suite("Versions", testVersions, spec.Parallel())
 	suite.Run(t)
 }

--- a/integration/versions_test.go
+++ b/integration/versions_test.go
@@ -1,0 +1,133 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testVersions(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+	})
+
+	context("when the buildpack is run with pack build", func() {
+		var (
+			name   string
+			source string
+
+			containersMap map[string]interface{}
+			imagesMap     map[string]interface{}
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+
+			containersMap = map[string]interface{}{}
+			imagesMap = map[string]interface{}{}
+		})
+
+		it.After(func() {
+			for containerID := range containersMap {
+				Expect(docker.Container.Remove.Execute(containerID)).To(Succeed())
+			}
+			for imageID := range imagesMap {
+				Expect(docker.Image.Remove.Execute(imageID)).To(Succeed())
+			}
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		it("builds and runs successfully with both provided dependency versions", func() {
+			var err error
+
+			source, err = occam.Source(filepath.Join("testdata", "default_app"))
+			Expect(err).NotTo(HaveOccurred())
+
+			firstPoetryVersion := buildpackInfo.Metadata.Dependencies[0].Version
+			secondPoetryVersion := buildpackInfo.Metadata.Dependencies[1].Version
+
+			Expect(firstPoetryVersion).NotTo(Equal(secondPoetryVersion))
+
+			firstImage, firstLogs, err := pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.CPython.Online,
+					settings.Buildpacks.Pip.Online,
+					settings.Buildpacks.Poetry.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).
+				WithEnv(map[string]string{"BP_POETRY_VERSION": firstPoetryVersion}).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), firstLogs.String)
+
+			imagesMap[firstImage.ID] = nil
+
+			Expect(firstLogs).To(ContainLines(
+				ContainSubstring(fmt.Sprintf(`Selected Poetry version (using BP_POETRY_VERSION): %s`, firstPoetryVersion)),
+			))
+
+			firstContainer, err := docker.Container.Run.
+				WithCommand("poetry --version").
+				Execute(firstImage.ID)
+			Expect(err).ToNot(HaveOccurred())
+
+			containersMap[firstContainer.ID] = nil
+
+			Eventually(func() string {
+				cLogs, err := docker.Container.Logs.Execute(firstContainer.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cLogs.String()
+			}).Should(ContainSubstring(fmt.Sprintf(`Poetry version %s`, firstPoetryVersion)))
+
+			secondImage, secondLogs, err := pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.CPython.Online,
+					settings.Buildpacks.Pip.Online,
+					settings.Buildpacks.Poetry.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).
+				WithEnv(map[string]string{"BP_POETRY_VERSION": secondPoetryVersion}).
+				Execute(name, source)
+			Expect(err).ToNot(HaveOccurred(), secondLogs.String)
+
+			imagesMap[secondImage.ID] = nil
+
+			Expect(secondLogs).To(ContainLines(
+				ContainSubstring(fmt.Sprintf(`Selected Poetry version (using BP_POETRY_VERSION): %s`, secondPoetryVersion)),
+			))
+
+			secondContainer, err := docker.Container.Run.
+				WithCommand("poetry --version").
+				Execute(secondImage.ID)
+			Expect(err).ToNot(HaveOccurred())
+
+			containersMap[secondContainer.ID] = nil
+
+			Eventually(func() string {
+				cLogs, err := docker.Container.Logs.Execute(secondContainer.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cLogs.String()
+			}).Should(ContainSubstring(fmt.Sprintf(`Poetry version %s`, secondPoetryVersion)))
+		})
+	})
+}

--- a/poetry_install_process.go
+++ b/poetry_install_process.go
@@ -26,14 +26,13 @@ func NewPoetryInstallProcess(executable Executable) PoetryInstallProcess {
 	}
 }
 
-// Execute installs the poetry binary from source code located in the given
-// srcPath into the layer path designated by targetLayerPath.
-func (p PoetryInstallProcess) Execute(srcPath, targetLayerPath string) error {
+// Execute installs the provided version of pipenv from the internet into the
+// layer path designated by targetLayerPath
+func (p PoetryInstallProcess) Execute(version, targetLayerPath string) error {
 	buffer := bytes.NewBuffer(nil)
 
 	err := p.executable.Execute(pexec.Execution{
-		// Install poetry from source with the pip that comes from a previous buildpack
-		Args: []string{"install", "poetry", "--user", fmt.Sprintf("--find-links=%s", srcPath)},
+		Args: []string{"install", fmt.Sprintf("poetry==%s", version), "--user"},
 		// Set the PYTHONUSERBASE to ensure that pip is installed to the newly created target layer.
 		Env:    append(os.Environ(), fmt.Sprintf("PYTHONUSERBASE=%s", targetLayerPath)),
 		Stdout: buffer,

--- a/poetry_install_process_test.go
+++ b/poetry_install_process_test.go
@@ -18,7 +18,7 @@ func testPoetryInstallProcess(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		srcPath       string
+		version       string
 		destLayerPath string
 		executable    *fakes.Executable
 
@@ -27,11 +27,10 @@ func testPoetryInstallProcess(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		srcPath, err = os.MkdirTemp("", "poetry-source")
-		Expect(err).NotTo(HaveOccurred())
-
 		destLayerPath, err = os.MkdirTemp("", "poetry")
 		Expect(err).NotTo(HaveOccurred())
+
+		version = "1.2.3-some.version"
 
 		executable = &fakes.Executable{}
 
@@ -41,11 +40,11 @@ func testPoetryInstallProcess(t *testing.T, context spec.G, it spec.S) {
 	context("Execute", func() {
 		context("there is a poetry dependency to install", func() {
 			it("installs it to the poetry layer", func() {
-				err := poetryInstallProcess.Execute(srcPath, destLayerPath)
+				err := poetryInstallProcess.Execute(version, destLayerPath)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(executable.ExecuteCall.Receives.Execution.Env).To(Equal(append(os.Environ(), fmt.Sprintf("PYTHONUSERBASE=%s", destLayerPath))))
-				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{"install", "poetry", "--user", fmt.Sprintf("--find-links=%s", srcPath)}))
+				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{"install", "poetry==1.2.3-some.version", "--user"}))
 			})
 		})
 
@@ -60,7 +59,7 @@ func testPoetryInstallProcess(t *testing.T, context spec.G, it spec.S) {
 				})
 
 				it("returns an error", func() {
-					err := poetryInstallProcess.Execute(srcPath, destLayerPath)
+					err := poetryInstallProcess.Execute(version, destLayerPath)
 					Expect(err).To(MatchError(ContainSubstring("installing poetry failed")))
 					Expect(err).To(MatchError(ContainSubstring("stdout output")))
 					Expect(err).To(MatchError(ContainSubstring("stderr output")))


### PR DESCRIPTION
## Summary

In #57 we noticed that we do not respect `BP_POETRY_VERSION` - instead we always install the most recent version from the internet.

This PR fixes that by installing `poetry` with `pip install poetry==<version>`. We also stop downloading the dependency tarball during the build phase as we no longer use it. We add an integration test explicitly testing that we install each of the versions declared in the buildpack.toml. This is structurally identical to: https://github.com/paketo-buildpacks/pipenv/pull/223.

We also bump the integration test timeout to a more reasonable value.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
