### PR TITLE
Use occam.Source in integration tests.

### DIFF
--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -40,6 +40,9 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			var err error
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "default_app"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		it.After(func() {
@@ -53,9 +56,6 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 		it("builds with the defaults", func() {
 			var err error
 			var logs fmt.Stringer
-
-			source, err = occam.Source(filepath.Join("testdata", "default_app"))
-			Expect(err).NotTo(HaveOccurred())
 
 			image, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
@@ -134,9 +134,6 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			it("writes SBOM files to the layer and label metadata", func() {
 				var err error
 				var logs fmt.Stringer
-
-				source, err = occam.Source(filepath.Join("testdata", "default_app"))
-				Expect(err).NotTo(HaveOccurred())
 
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").

--- a/integration/versions_test.go
+++ b/integration/versions_test.go
@@ -43,6 +43,9 @@ func testVersions(t *testing.T, context spec.G, it spec.S) {
 
 			containersMap = map[string]interface{}{}
 			imagesMap = map[string]interface{}{}
+
+			source, err = occam.Source(filepath.Join("testdata", "default_app"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		it.After(func() {
@@ -58,9 +61,6 @@ func testVersions(t *testing.T, context spec.G, it spec.S) {
 
 		it("builds and runs successfully with both provided dependency versions", func() {
 			var err error
-
-			source, err = occam.Source(filepath.Join("testdata", "default_app"))
-			Expect(err).NotTo(HaveOccurred())
 
 			firstPoetryVersion := buildpackInfo.Metadata.Dependencies[0].Version
 			secondPoetryVersion := buildpackInfo.Metadata.Dependencies[1].Version


### PR DESCRIPTION
## Summary

This PR ensures that each test uses `occam.Source` in a consistent manner. This ensures that we do not accidentally re-use images across tests.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
