### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Poetry Cloud Native Buildpack
 ## `gcr.io/paketo-buildpacks/poetry`
 
-The Paketo Poetry Buildpack is a Cloud Native Buildpack that installs [Poetry](https://python-poetry.org/) into a
+The Paketo Buildpack for Poetry is a Cloud Native Buildpack that installs [Poetry](https://python-poetry.org/) into a
 layer and places it on the `PATH`.
 
 The buildpack is published for consumption at `gcr.io/paketo-buildpacks/poetry` and

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.7"
 
 [buildpack]
   id = "paketo-buildpacks/poetry"
-  name = "Paketo Poetry Buildpack"
+  name = "Paketo Buildpack for Poetry"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Poetry Buildpack' to 'Paketo Buildpack for Poetry'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
