### PR TITLE
Add support for poetry v1.2.x

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -14,6 +14,32 @@ api = "0.7"
   pre-package = "./scripts/build.sh"
 
   [[metadata.dependencies]]
+    checksum = "sha256:17c527d5d5505a5a7c5c14348d87f077d643cf1f186321530cde68e530bba59f"
+    cpe = "cpe:2.3:a:python-poetry:poetry:1.2.0:*:*:*:*:python:*:*"
+    id = "poetry"
+    licenses = ["MIT"]
+    name = "Poetry"
+    purl = "pkg:generic/poetry@1.2.0?checksum=17c527d5d5505a5a7c5c14348d87f077d643cf1f186321530cde68e530bba59f&download_url=https://files.pythonhosted.org/packages/d6/75/2603419dcfafb3e777b304c9cb2813a8a4090db04356b750a662663c3c01/poetry-1.2.0.tar.gz"
+    source = "https://files.pythonhosted.org/packages/d6/75/2603419dcfafb3e777b304c9cb2813a8a4090db04356b750a662663c3c01/poetry-1.2.0.tar.gz"
+    source-checksum = "sha256:17c527d5d5505a5a7c5c14348d87f077d643cf1f186321530cde68e530bba59f"
+    stacks = ["*"]
+    uri = "https://files.pythonhosted.org/packages/d6/75/2603419dcfafb3e777b304c9cb2813a8a4090db04356b750a662663c3c01/poetry-1.2.0.tar.gz"
+    version = "1.2.0"
+
+  [[metadata.dependencies]]
+    checksum = "sha256:2750bb2b636ef435d8beac51dde0b13d06199017a1d9b96cba899863d1e81024"
+    cpe = "cpe:2.3:a:python-poetry:poetry:1.2.1:*:*:*:*:python:*:*"
+    id = "poetry"
+    licenses = ["MIT"]
+    name = "Poetry"
+    purl = "pkg:generic/poetry@1.2.1?checksum=2750bb2b636ef435d8beac51dde0b13d06199017a1d9b96cba899863d1e81024&download_url=https://files.pythonhosted.org/packages/fa/73/e0870cd0049aff899a03ed04b9f3dc2642cce083f2c0eb6e276906b5c1ea/poetry-1.2.1.tar.gz"
+    source = "https://files.pythonhosted.org/packages/fa/73/e0870cd0049aff899a03ed04b9f3dc2642cce083f2c0eb6e276906b5c1ea/poetry-1.2.1.tar.gz"
+    source-checksum = "sha256:2750bb2b636ef435d8beac51dde0b13d06199017a1d9b96cba899863d1e81024"
+    stacks = ["*"]
+    uri = "https://files.pythonhosted.org/packages/fa/73/e0870cd0049aff899a03ed04b9f3dc2642cce083f2c0eb6e276906b5c1ea/poetry-1.2.1.tar.gz"
+    version = "1.2.1"
+
+  [[metadata.dependencies]]
     checksum = "sha256:8b5a7676cda9b9e85c71743c672352cabcb6e2f647b6b88fa95e4f374bc8edce"
     cpe = "cpe:2.3:a:python-poetry:poetry:1.1.14:*:*:*:*:python:*:*"
     id = "poetry"
@@ -38,6 +64,11 @@ api = "0.7"
     stacks = ["*"]
     uri = "https://files.pythonhosted.org/packages/e0/c8/09e126761651e291ab54db1b1d6983c64a1cf67b8b25ce9c806db23e16ab/poetry-1.1.15.tar.gz"
     version = "1.1.15"
+
+  [[metadata.dependency-constraints]]
+    constraint = "1.2.*"
+    id = "poetry"
+    patches = 2
 
   [[metadata.dependency-constraints]]
     constraint = "1.1.*"

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -110,7 +110,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				cLogs, err := docker.Container.Logs.Execute(container.ID)
 				Expect(err).NotTo(HaveOccurred())
 				return cLogs.String()
-			}).Should(MatchRegexp(`Poetry version \d+\.\d+\.\d+`))
+			}).Should(MatchRegexp(`Poetry.*version \d+\.\d+\.\d+`))
 		})
 
 		context("validating SBOM", func() {
@@ -159,7 +159,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 					cLogs, err := docker.Container.Logs.Execute(container.ID)
 					Expect(err).NotTo(HaveOccurred())
 					return cLogs.String()
-				}).Should(MatchRegexp(`Poetry version \d+\.\d+\.\d+`))
+				}).Should(MatchRegexp(`Poetry.*version \d+\.\d+\.\d+`))
 
 				Expect(logs).To(ContainLines(
 					fmt.Sprintf("  Generating SBOM for /layers/%s/poetry", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -93,7 +93,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				cLogs, err := docker.Container.Logs.Execute(firstContainer.ID)
 				Expect(err).NotTo(HaveOccurred())
 				return cLogs.String()
-			}).Should(MatchRegexp(`Poetry version \d+\.\d+\.\d+`))
+			}).Should(MatchRegexp(`Poetry.*version \d+\.\d+\.\d+`))
 
 			secondImage, logs, err := pack.WithNoColor().Build.
 				WithPullPolicy("never").
@@ -123,7 +123,7 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				cLogs, err := docker.Container.Logs.Execute(secondContainer.ID)
 				Expect(err).NotTo(HaveOccurred())
 				return cLogs.String()
-			}).Should(MatchRegexp(`Poetry version \d+\.\d+\.\d+`))
+			}).Should(MatchRegexp(`Poetry.*version \d+\.\d+\.\d+`))
 
 			Expect(secondImage.Buildpacks[0].Layers["poetry"].SHA).To(Equal(firstImage.Buildpacks[0].Layers["poetry"].SHA))
 		})

--- a/integration/versions_test.go
+++ b/integration/versions_test.go
@@ -59,7 +59,7 @@ func testVersions(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
-		it("builds and runs successfully with both provided dependency versions", func() {
+		it("builds and runs successfully with multiple provided dependency versions", func() {
 			var err error
 
 			firstPoetryVersion := buildpackInfo.Metadata.Dependencies[0].Version
@@ -96,7 +96,7 @@ func testVersions(t *testing.T, context spec.G, it spec.S) {
 				cLogs, err := docker.Container.Logs.Execute(firstContainer.ID)
 				Expect(err).NotTo(HaveOccurred())
 				return cLogs.String()
-			}).Should(ContainSubstring(fmt.Sprintf(`Poetry version %s`, firstPoetryVersion)))
+			}).Should(MatchRegexp(fmt.Sprintf(`Poetry.*version %s`, firstPoetryVersion)))
 
 			secondImage, secondLogs, err := pack.WithNoColor().Build.
 				WithPullPolicy("never").
@@ -127,7 +127,7 @@ func testVersions(t *testing.T, context spec.G, it spec.S) {
 				cLogs, err := docker.Container.Logs.Execute(secondContainer.ID)
 				Expect(err).NotTo(HaveOccurred())
 				return cLogs.String()
-			}).Should(ContainSubstring(fmt.Sprintf(`Poetry version %s`, secondPoetryVersion)))
+			}).Should(MatchRegexp(fmt.Sprintf(`Poetry.*version %s`, secondPoetryVersion)))
 		})
 	})
 }


### PR DESCRIPTION
## Summary

This PR adds support for Poetry v1.2.x. This was achieved by manually running the new retrieval and jam update-dependencies flow.

The integration test changes are because the new output of `poetry --version` is `poetry (version 1.2.3)` whereas it used to be: `poetry version 1.2.3`. The `.*` regex allows us to match both cases.

Resolves #106 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
